### PR TITLE
Handle missing FlashAttention gracefully

### DIFF
--- a/models/layers.py
+++ b/models/layers.py
@@ -7,8 +7,10 @@ import torch.nn.functional as F
 try:
     from flash_attn_interface import flash_attn_func  # type: ignore[import]
 except ImportError:
-    # Fallback to FlashAttention 2
-    from flash_attn import flash_attn_func  # type: ignore[import]
+    try:
+        from flash_attn import flash_attn_func  # type: ignore[import]
+    except ImportError:
+        flash_attn_func = None  # flash_attn_func being None signals the fallback path
 
 from models.common import trunc_normal_init_
 


### PR DESCRIPTION
## Summary
- Replace FlashAttention import logic with nested try/except blocks that set `flash_attn_func` to `None` when neither `flash_attn_interface` nor `flash_attn` is available, signaling the fallback path.

## Testing
- `python -m py_compile models/layers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6074e7e483238787bfd75b319902