### PR TITLE
Handle missing flash attention imports

### DIFF
--- a/models/layers.py
+++ b/models/layers.py
@@ -5,12 +5,13 @@ from torch import nn
 import torch.nn.functional as F
 
 try:
-    from flash_attn_interface import flash_attn_func  # type: ignore[import]
-except Exception:  # pragma: no cover - flash attention not available
     try:
-        from flash_attn import flash_attn_func  # type: ignore[import]
+        from flash_attn_interface import flash_attn_func  # type: ignore[import]
     except Exception:  # pragma: no cover - flash attention not available
-        flash_attn_func = None  # type: ignore
+        from flash_attn import flash_attn_func  # type: ignore[import]
+except Exception:  # pragma: no cover - flash attention not available
+    flash_attn_func = None  # type: ignore
+    # flash_attn_func being None signals the fallback path
 
 from models.common import trunc_normal_init_
 


### PR DESCRIPTION
## Summary
- Refactor flash attention imports to nested try/except blocks and add a fallback when unavailable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f65907d488323a98724a3c6a9b7a0